### PR TITLE
Make license match SPDX ID

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,7 @@
   <date>2023.06.10</date>
   <author email="fco.rosa@yahoo.com.br">F_Rosa</author>  
   <maintainer email="fco.rosa@yahoo.com.br">F_Rosa</maintainer>  
-  <license file="LICENSE">LGPLv2.1</license>
+  <license file="LICENSE">LGPL-2.1-or-later</license>
   <freecadmin>0.20.0</freecadmin>
   <url type="repository" branch="master">https://github.com/Francisco-Rosa/FreeCAD-Movie</url>
   <url type="readme">https://github.com/Francisco-Rosa/FreeCAD-Movie/blob/master/README.md</url>


### PR DESCRIPTION
See https://spdx.org/licenses/ -- note that you might actually mean `LGPL-2.1-only`, in which case use that instead.
